### PR TITLE
1 rename package from hcesr to hcesnutr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
-Package: hcesR
+Package: hcesNutR
 Type: Package
 Title: Households Consumption Expenditure Survey (HCES) Data Analysis
-Version: 0.1.0
+Version: 0.0.001
 Authors@R:   c(person(given = "Liberty",
                        family = "Mlambo",
                        role = c("aut", "cre"),
@@ -23,7 +23,7 @@ Authors@R:   c(person(given = "Liberty",
                        family = "Ander",
                        role = c("aut","ctb"),
                        comment = c(ORCID = "-")),
-                  person("Micronutrient Action Policy Support Project", role = c("cph", "fnd")))
+                  person("Micronutrient Action Policy Support (MAPS) Project", role = c("cph", "fnd")))
 Maintainer: The package maintainer <liberty.mlambo@nottingham.ac.uk>
 Description: Functions for analysing HCES data. 
     The package contains functions for data cleaning, data manipulation, data visualisation and data analysis. The package also contains a dataset of the standard units and names of food items.
@@ -42,3 +42,7 @@ Imports:
     here,
     rlang
     
+    
+    
+
+

--- a/R/clean_hces.R
+++ b/R/clean_hces.R
@@ -8,7 +8,7 @@ get_hces_mappings <- function(country_name, survey_name) {
     #' @export
 
     # Extract column mappings from the internal database
-    column_mapping <- hcesR::standard_name_mappings_pairs |>
+    column_mapping <- hcesNutR::standard_name_mappings_pairs |>
         dplyr::filter(country == country_name & survey == survey_name) |>
         dplyr::filter(!is.na(hces_standard_name))
 
@@ -58,7 +58,7 @@ rename_hces <- function(data,country_name,survey_name) {
     #' @export
 
     # Extraxt column mappings from the internal database
-    column_mapping <- hcesR::get_hces_mappings(country_name,survey_name) |>
+    column_mapping <- hcesNutR::get_hces_mappings(country_name,survey_name) |>
         # Remove rows with no standard name
         dplyr::filter(hces_standard_name != "") |>
         # Remove rows with no survey variable name in the original data
@@ -72,7 +72,7 @@ rename_hces <- function(data,country_name,survey_name) {
     }
 
     # Check for columns that have been renamed
-    data <- hcesR::check_hces_names(data, original_data_df)
+    data <- hcesNutR::check_hces_names(data, original_data_df)
 
     return(data)
 }
@@ -178,7 +178,7 @@ which_labelled <- function(data)
       labelled_variables <- c(labelled_variables, x)
     }
   }
-  message("The following variables are labelled: Use `hcesR::split_dta()` to split the data into two separate columns.")
+  message("The following variables are labelled: Use `hcesNutR::split_dta()` to split the data into two separate columns.")
   return(labelled_variables)
 }
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -26,7 +26,7 @@ You can install the development version of hcesR2 from [GitHub](https://github.c
 
 ``` r
 # install.packages("devtools")
-devtools::install_github("dzvoti/hcesR")
+devtools::install_github("dzvoti/hcesNutR")
 ```
 
 ## Example
@@ -34,5 +34,5 @@ devtools::install_github("dzvoti/hcesR")
 This is a basic example which shows you how to solve a common problem:
 
 ```{r example}
-library(hcesR)
+library(hcesNutR)
 ```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can install the development version of hcesR2 from
 
 ``` r
 # install.packages("devtools")
-devtools::install_github("dzvoti/hcesR")
+devtools::install_github("dzvoti/hcesNutR")
 ```
 
 ## Example
@@ -29,5 +29,5 @@ devtools::install_github("dzvoti/hcesR")
 This is a basic example which shows you how to solve a common problem:
 
 ``` r
-library(hcesR)
+library(hcesNutR)
 ```


### PR DESCRIPTION
Update package name to `hcesNutR`

This pull request updates the package name from `hcesR` to `hcesNutR` in all occurrences in `DESCRIPTION`, `clean_hces.R`, and `README.md`. The change was made to better reflect the purpose of the package, which is to provide functions for the analysis of the Household Consumption Expenditure Survey (HCES) data with a focus on nutrition. The package name change is consistent with the GitHub repository name and the package namespace.